### PR TITLE
Add annotation to stop "Unable to detect parameter names for query method" message

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/services/persistence/repository/InvitedataRepository.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/persistence/repository/InvitedataRepository.java
@@ -15,5 +15,5 @@ public interface InvitedataRepository extends PagingAndSortingRepository<Invited
     Invitedata findById(@Param("id") String id);
 
     @RestResource(path = "formdata")
-    List<Invitedata> findByFormdataId(String id);
+    List<Invitedata> findByFormdataId(@Param("id") String id);
 }


### PR DESCRIPTION
Add annotation to stop "Unable to detect parameter names for query method" message

