### PR TITLE
PRO-3036: Updated to show health endpoint properties.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,13 @@
 *.iml
 target/
 .DS_Store
+git.properties
+.project
+.classpath
 /nbactions.xml
 .gradle/
 build/
+.settings/
+bin/
 out/
 classes/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,11 @@
 ---
+security:
+  basic:
+    enabled: false
 
+management:
+  security:
+    enabled: false
 
 spring:
   application:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3036

### Change description ###
Simple change which exposes the properties for the /health endpoint to be consistent with Business and Submit backend services. No new checks have been included other than the existing checks Spring Actuator does already which is DB and diskSpace.

Example output of health check is as follows:
{"status":"UP","diskSpace":{"status":"UP","total":499963170816,"free":422917586944,"threshold":10485760},"db":{"status":"UP","database":"PostgreSQL","hello":1}}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
